### PR TITLE
Hide JJB INI File Diffs from Puppet Reports

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -54,9 +54,10 @@ class jjb::config (
   }
 
   ini_config {$ini_file:
-    config => $_config,
-    group  => $ini_group,
-    mode   => $ini_mode,
-    owner  => $ini_owner,
+    config    => $_config,
+    group     => $ini_group,
+    mode      => $ini_mode,
+    owner     => $ini_owner,
+    show_diff => false,
   }
 }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -37,8 +37,9 @@ describe 'jjb::config' do
             'url'      => 'https://localhost:8080',
           },
         },
-        :owner  => params['ini_owner'],
-        :group  => params['ini_group'],
+        :owner     => params['ini_owner'],
+        :group     => params['ini_group'],
+        :show_diff => false,
       ) }
 
       it 'should have a merged config' do


### PR DESCRIPTION
Because the JJB ini file contains a password for uploading jobs, the
file should by default have it's diff hidden. This should also not be a
configurable option as misconfiguration could lead to passwords being
leaked in the clear.

(depends on https://github.com/tykeal/puppet-ini_config/pull/1)

Signed-off-by: Trevor Bramwell tbramwell@linuxfoundation.org
